### PR TITLE
Added async overrides

### DIFF
--- a/src/BlazorComponentBus.Extensions.DependencyInjection/BlazorComponentBus.Extensions.DependencyInjection.csproj
+++ b/src/BlazorComponentBus.Extensions.DependencyInjection/BlazorComponentBus.Extensions.DependencyInjection.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorComponentBus\BlazorComponentBus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/BlazorComponentBus.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/BlazorComponentBus.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace BlazorComponentBus.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+
+    public static IServiceCollection AddBlazorComponentBus(this IServiceCollection services)
+    {
+        services.AddScoped<IComponentBus, ComponentBus>();
+        services.AddScoped<ComponentBus>();
+        return services;
+    }
+
+}

--- a/src/BlazorComponentBus.UnitTests/BlazorComponentBus.UnitTests.csproj
+++ b/src/BlazorComponentBus.UnitTests/BlazorComponentBus.UnitTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -21,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BlazorComponentBus.Extensions.DependencyInjection\BlazorComponentBus.Extensions.DependencyInjection.csproj" />
     <ProjectReference Include="..\BlazorComponentBus\BlazorComponentBus.csproj" />
   </ItemGroup>
 

--- a/src/BlazorComponentBus.UnitTests/ComponentBusTests.cs
+++ b/src/BlazorComponentBus.UnitTests/ComponentBusTests.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -13,9 +13,9 @@ namespace BlazorComponentBus.UnitTests
             var bus = new ComponentBus();
             var publisher = new PublishingComponent(bus);
             var subscriber = new SubscribingComponent();
-            
+
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
-            
+
             await publisher.PublishTestMessageEvent();
 
             Assert.Equal(1, subscriber.Count);
@@ -27,36 +27,40 @@ namespace BlazorComponentBus.UnitTests
             var bus = new ComponentBus();
             var publisher = new PublishingComponent(bus);
             var subscriber = new SubscribingComponent();
-            
+
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
-            
+
             subscriber.UnsubscribeThisComponent<TestEventMessage>(bus);
-            
+
             await publisher.PublishTestMessageEvent();
 
             Assert.Equal(0, subscriber.Count);
         }
-        
+
         [Fact]
         public void ShouldNotFailIfNoSubscriberFoundWhenUnsubscribing()
         {
             var bus = new ComponentBus();
             var subscriber = new SubscribingComponent();
-            
+
             //There is no subscriber but we are going to try an unsubscribe anyway
             subscriber.UnsubscribeThisComponent<TestEventMessage>(bus);
+
+            Assert.True(true);
         }
-        
+
         [Fact]
         public async Task ShouldNotFailIfPublishWithNoSubscribers()
         {
             var bus = new ComponentBus();
             var publisher = new PublishingComponent(bus);
-            
+
             //There is no subscriber but we are going to try and publish an event
             await publisher.PublishTestMessageEvent();
+
+            Assert.True(true);
         }
-        
+
         [Fact]
         public async Task ShouldOnlyUnsubscribeOneComponentAndNotAll()
         {
@@ -64,10 +68,10 @@ namespace BlazorComponentBus.UnitTests
             var publisher = new PublishingComponent(bus);
             var subscriber = new SubscribingComponent(); //Different Type
             var secondSubscriber = new SecondSubscribingComponent(); //Different Type
-            
+
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
             secondSubscriber.SubscribeThisComponent<TestEventMessage>(bus);
-            
+
             subscriber.UnsubscribeThisComponent<TestEventMessage>(bus);
 
             await publisher.PublishTestMessageEvent();
@@ -75,7 +79,7 @@ namespace BlazorComponentBus.UnitTests
             Assert.Equal(0, subscriber.Count);
             Assert.Equal(1, secondSubscriber.Count);
         }
-        
+
         [Fact]
         public async Task ShouldOnlyUnsubscribeOneComponentAndNotAllMultiInstance()
         {
@@ -83,10 +87,10 @@ namespace BlazorComponentBus.UnitTests
             var publisher = new PublishingComponent(bus);
             var subscriber = new SubscribingComponent(); //Same Type
             var secondSubscriber = new SubscribingComponent(); //Same Type
-            
+
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
             secondSubscriber.SubscribeThisComponent<TestEventMessage>(bus);
-            
+
             subscriber.UnsubscribeThisComponent<TestEventMessage>(bus);
 
             await publisher.PublishTestMessageEvent();
@@ -94,7 +98,7 @@ namespace BlazorComponentBus.UnitTests
             Assert.Equal(0, subscriber.Count);
             Assert.Equal(1, secondSubscriber.Count);
         }
-        
+
         [Fact]
         public async Task ShouldOnlyUnsubscribeOneEventType()
         {
@@ -104,15 +108,15 @@ namespace BlazorComponentBus.UnitTests
 
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
             subscriber.SubscribeThisComponent<AnotherTestEventMessage>(bus);
-            
+
             subscriber.UnsubscribeThisComponent<TestEventMessage>(bus);
 
             await publisher.PublishTestMessageEvent();
             await publisher.PublishAnotherTestEventMessage();
-            
+
             Assert.Equal(1, subscriber.Count);
         }
-        
+
         [Fact]
         public async Task ShouldSubscribeTo2Events()
         {
@@ -122,20 +126,70 @@ namespace BlazorComponentBus.UnitTests
 
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
             subscriber.SubscribeThisComponent<AnotherTestEventMessage>(bus);
-            
+
 
             await publisher.PublishTestMessageEvent();
             await publisher.PublishAnotherTestEventMessage();
-            
+
             Assert.Equal(2, subscriber.Count);
         }
-        
+
         [Fact]
         public async Task MultiSubscribeToSameMessageShouldOnlyGetOneResult()
         {
             var bus = new ComponentBus();
             var publisher = new PublishingComponent(bus);
             var subscriber = new SubscribingComponent();
+
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+
+            await publisher.PublishTestMessageEvent();
+
+            Assert.Equal(1, subscriber.Count);
+        }
+
+        [Fact]
+        public async Task AsyncSubscribeShouldSubscribeToAndPublishAnEvent()
+        {
+            var bus = new ComponentBus();
+            var publisher = new PublishingComponent(bus);
+            var subscriber = new AsyncSubscribingComponent();
+
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+
+            await publisher.PublishTestMessageEvent();
+
+            Assert.Equal(1, subscriber.Count);
+        }
+
+        [Fact]
+        public async Task AsyncSubscribeShouldUnsubscribe()
+        {
+            var bus = new ComponentBus();
+            var publisher = new PublishingComponent(bus);
+            var subscriber = new AsyncSubscribingComponent();
+
+            subscriber.SubscribeThisComponent<TestEventMessage>(bus);
+            subscriber.UnsubscribeThisComponent<TestEventMessage>(bus);
+
+            await publisher.PublishTestMessageEvent();
+
+            Assert.Equal(0, subscriber.Count);
+        }
+
+        [Fact]
+        public async Task AsyncSubscribeMultiSubscribeToSameMessageShouldOnlyGetOneResult()
+        {
+            var bus = new ComponentBus();
+            var publisher = new PublishingComponent(bus);
+            var subscriber = new AsyncSubscribingComponent();
 
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
             subscriber.SubscribeThisComponent<TestEventMessage>(bus);
@@ -169,7 +223,7 @@ namespace BlazorComponentBus.UnitTests
         {
             await _bus.Publish(new TestEventMessage());
         }
-        
+
         public async Task PublishAnotherTestEventMessage()
         {
             await _bus.Publish(new AnotherTestEventMessage());
@@ -189,13 +243,34 @@ namespace BlazorComponentBus.UnitTests
         {
             bus.UnSubscribe<T>(ReceiveMessage);
         }
-        
+
         public void ReceiveMessage(MessageArgs args)
         {
             Count++;
         }
     }
-    
+
+    public class AsyncSubscribingComponent
+    {
+        public int Count { get; set; }
+
+        public void SubscribeThisComponent<T>(ComponentBus bus)
+        {
+            bus.Subscribe<T>(ReceiveMessageAsync);
+        }
+
+        public void UnsubscribeThisComponent<T>(ComponentBus bus)
+        {
+            bus.UnSubscribe<T>(ReceiveMessageAsync);
+        }
+
+        public Task ReceiveMessageAsync(MessageArgs args, CancellationToken ct)
+        {
+            Count++;
+            return Task.CompletedTask;
+        }
+    }
+
     public class SecondSubscribingComponent
     {
         public int Count { get; set; }
@@ -209,18 +284,18 @@ namespace BlazorComponentBus.UnitTests
         {
             bus.UnSubscribe<T>(ReceiveMessage);
         }
-        
+
         public void ReceiveMessage(MessageArgs args)
         {
             Count++;
         }
     }
-    
+
     public class TestEventMessage
     {
 
     }
-    
+
     public class AnotherTestEventMessage
     {
 

--- a/src/BlazorComponentBus.UnitTests/DependencyInjectionTests.cs
+++ b/src/BlazorComponentBus.UnitTests/DependencyInjectionTests.cs
@@ -1,0 +1,25 @@
+﻿using BlazorComponentBus.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BlazorComponentBus.UnitTests;
+
+
+public sealed class DependencyInjectionTests
+{
+
+    [Fact]
+    public void ServiceProviderShouldInjectIComponentBus()
+    {
+        using var serviceProvider = new ServiceCollection().AddBlazorComponentBus().BuildServiceProvider();
+        Assert.NotNull(serviceProvider.GetService<IComponentBus>());
+    }
+
+    [Fact]
+    public void ServiceProviderShouldInjectComponentBus()
+    {
+        using var serviceProvider = new ServiceCollection().AddBlazorComponentBus().BuildServiceProvider();
+        Assert.NotNull(serviceProvider.GetService<ComponentBus>());
+    }
+
+}

--- a/src/BlazorComponentBus.sln
+++ b/src/BlazorComponentBus.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorComponentBus", "BlazorComponentBus\BlazorComponentBus.csproj", "{9C12BC91-5860-4DE5-9F00-D4CE67E85A53}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorComponentBus.UnitTests", "BlazorComponentBus.UnitTests\BlazorComponentBus.UnitTests.csproj", "{7BC69FB0-6486-4E1A-A080-C7DD2B01EF8E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorComponentBus.UnitTests", "BlazorComponentBus.UnitTests\BlazorComponentBus.UnitTests.csproj", "{7BC69FB0-6486-4E1A-A080-C7DD2B01EF8E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorComponentBus.Extensions.DependencyInjection", "BlazorComponentBus.Extensions.DependencyInjection\BlazorComponentBus.Extensions.DependencyInjection.csproj", "{536D7AE4-6B77-4EE1-8D9B-10EDD3BBEECF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{7BC69FB0-6486-4E1A-A080-C7DD2B01EF8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BC69FB0-6486-4E1A-A080-C7DD2B01EF8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BC69FB0-6486-4E1A-A080-C7DD2B01EF8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{536D7AE4-6B77-4EE1-8D9B-10EDD3BBEECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{536D7AE4-6B77-4EE1-8D9B-10EDD3BBEECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{536D7AE4-6B77-4EE1-8D9B-10EDD3BBEECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{536D7AE4-6B77-4EE1-8D9B-10EDD3BBEECF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BlazorComponentBus/ComponentBus.cs
+++ b/src/BlazorComponentBus/ComponentBus.cs
@@ -1,46 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using BlazorComponentBus.Subscribing;
+﻿using BlazorComponentBus.Subscribing;
 
-namespace BlazorComponentBus
+namespace BlazorComponentBus;
+
+public class ComponentBus : IComponentBus
 {
-    public class ComponentBus
+    private readonly List<KeyValuePair<Type, object>> _registeredComponents = new();
+
+
+    public void Subscribe<T>(ComponentCallBack<MessageArgs> componentCallback) =>
+        Subscribe<T>(componentCallback as object);
+
+    public void Subscribe<T>(AsyncComponentCallBack<MessageArgs> componentCallback) =>
+        Subscribe<T>(componentCallback as object);
+
+    private void Subscribe<T>(object componentCallback)
     {
-        private List<KeyValuePair<Type, ComponentCallBack<MessageArgs>>> _registeredComponents = 
-            new List<KeyValuePair<Type, ComponentCallBack<MessageArgs>>>();
+        /* Unsubscribe first just in case the same component subscribes to the same callback twice.
+        This Prevents multiple callbacks to the same component. */
+        UnSubscribe<T>(componentCallback);
 
+        _registeredComponents.Add(new KeyValuePair<Type, object>(typeof(T), componentCallback));
+    }
 
-        public void Subscribe<T>(ComponentCallBack<MessageArgs> componentCallBack)
+    public void UnSubscribe<T>(ComponentCallBack<MessageArgs> componentCallBack) =>
+        UnSubscribe<T>(componentCallBack as object);
+
+    public void UnSubscribe<T>(AsyncComponentCallBack<MessageArgs> componentCallBack) =>
+        UnSubscribe<T>(componentCallBack as object);
+
+    private void UnSubscribe<T>(object componentCallBack)
+    {
+        _registeredComponents.Remove(new KeyValuePair<Type, object>(typeof(T), componentCallBack));
+    }
+
+    public async Task Publish<T>(T message, CancellationToken ct = default)
+    {
+        var messageType = typeof(T);
+
+        var args = new MessageArgs(message!);
+
+        var subscribers = _registeredComponents.ToLookup(item => item.Key);
+
+        //Look for subscribers of this message type
+        //Call the subscriber and pass the message along
+        foreach (var subscriber in subscribers[messageType].Select(_ => _.Value))
         {
-            /* Unsubscribe first just in case the same component subscribes to the same callback twice.
-            This Prevents multiple callbacks to the same component. */
-            UnSubscribe<T>(componentCallBack);
-            
-            _registeredComponents.Add(new KeyValuePair<Type, ComponentCallBack<MessageArgs>>(typeof(T), componentCallBack));
-        }
-        
-        public void UnSubscribe<T>(ComponentCallBack<MessageArgs> componentCallBack)
-        {
-            _registeredComponents.Remove(new KeyValuePair<Type, ComponentCallBack<MessageArgs>>(typeof(T), componentCallBack));
-        }
-        
-        public async Task Publish<T>(T message)
-        {
-            var messageType = typeof(T);
-
-            var args = new MessageArgs(message);
-
-            var subscribers = _registeredComponents.ToLookup(item => item.Key);
-
-            //Look for subscribers of this message type
-            //Call the subscriber and pass the message along
-            foreach (var subscriber in subscribers[messageType])
+            if (subscriber is ComponentCallBack<MessageArgs> syncCallback)
             {
-                await Task.Run(() => subscriber.Value.Invoke(args));
+                await Task.Run(() => syncCallback.Invoke(args), ct);
             }
-            
-        } 
+            else if (subscriber is AsyncComponentCallBack<MessageArgs> asyncCallback)
+            {
+                await Task.Run(() => asyncCallback.Invoke(args, ct), ct);
+            }
+        }
+
     }
 }

--- a/src/BlazorComponentBus/IComponentBus.cs
+++ b/src/BlazorComponentBus/IComponentBus.cs
@@ -1,0 +1,12 @@
+﻿using BlazorComponentBus.Subscribing;
+
+namespace BlazorComponentBus;
+
+public interface IComponentBus
+{
+    Task Publish<T>(T message, CancellationToken ct = default);
+    void Subscribe<T>(AsyncComponentCallBack<MessageArgs> componentCallback);
+    void Subscribe<T>(ComponentCallBack<MessageArgs> componentCallback);
+    void UnSubscribe<T>(AsyncComponentCallBack<MessageArgs> componentCallBack);
+    void UnSubscribe<T>(ComponentCallBack<MessageArgs> componentCallBack);
+}

--- a/src/BlazorComponentBus/MessageArgs.cs
+++ b/src/BlazorComponentBus/MessageArgs.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace BlazorComponentBus
+﻿namespace BlazorComponentBus
 {
     public class MessageArgs : EventArgs
     {

--- a/src/BlazorComponentBus/Subscribing/ComponentCallBack.cs
+++ b/src/BlazorComponentBus/Subscribing/ComponentCallBack.cs
@@ -1,4 +1,4 @@
-﻿namespace BlazorComponentBus.Subscribing
-{
-    public delegate void ComponentCallBack<TMessage>(TMessage message);
-}
+﻿namespace BlazorComponentBus.Subscribing;
+
+public delegate void ComponentCallBack<in TMessage>(TMessage message);
+public delegate Task AsyncComponentCallBack<in TMessage>(TMessage message, CancellationToken ct);


### PR DESCRIPTION
Thanks for a great library! I'm making extensive use of this in Blazor WASM. This PR adds three new features without creating any breaking changes:

- Adds new async delegate so that Subscribe can handle an asynchronous callback
- Extracts an IComponentBus interface so that that can be injected for testing/mocking purposes
- Adds an extension project for Microsoft's DI framework to easily add BlazorComponentBus to an IServiceCollection

Example of the async callback is:
```c-sharp
@inject BlazorComponentBus.IComponentBus Bus
<div>My Component</div>

@code
{
    protected override async Task OnInitializedAsync()
    {
        Bus.Subscribe<MyEvent>(DoSomething);
        Bus.Subscribe<MyEvent>(DoSomethingAsync);
    }

    private void DoSomething(MessageArgs args) 
    {
        // do something
    }

    private async Task DoSomethingAsync(MessageArgs args, CancellationToken ct) 
    {
        // await something
    }
}
```